### PR TITLE
port from react-test-renderer to rtl

### DIFF
--- a/templates/componentsDescribe.tpl
+++ b/templates/componentsDescribe.tpl
@@ -1,14 +1,15 @@
-<% if(parsedSource.exportComponents.length){%>const renderTree = tree => renderer.create(tree);<%}%>
 <% parsedSource.exportComponents.forEach(function(value) { %>describe('<<%=value.name %>>', () => {<% if(value.props.filter(function(prop) {return !prop.isOptional})){ %>
   it('should render component', () => {
-    expect(renderTree(<<%=value.name %> <% value.props.filter(function(prop) {return !prop.isOptional}).forEach(function(propType) { %> 
+    render(<<%=value.name %> <% value.props.filter(function(prop) {return !prop.isOptional}).forEach(function(propType) { %> 
       <%=propType.name %>={/* <%=propType.type %> */} <%}) %>
-    />).toJSON()).toMatchSnapshot();
+    />);
+    expect(document.querySelector('body')).toMatchSnapshot();
   });<%} %>
   <% if(value.props.length){ %>it('should render component with props', () => {
-    expect(renderTree(<<%=value.name %> <% value.props.forEach(function(propType) { %> 
+    render(<<%=value.name %> <% value.props.forEach(function(propType) { %> 
       <%=propType.name %>={/* <%=propType.type %> */} <%}) %>
-    />).toJSON()).toMatchSnapshot();
+    />);
+    expect(document.querySelector('body')).toMatchSnapshot();
   });<%} %>
 });
 <% })%>

--- a/templates/imports.tpl
+++ b/templates/imports.tpl
@@ -1,4 +1,4 @@
-<% if(parsedSource.exportComponents.length) {%>import renderer from 'react-test-renderer';
+<% if(parsedSource.exportComponents.length) {%>import { render } from '@testing-library/react';
 <% } %><% allImports.forEach(function(value) { %><%=value.importText %>
 <% }) %>import <%if(defaultExport)
 { %><%=defaultExport.name %><% }%><%=(defaultExport && namedExportsList.length ? ', ' : '') %><%if(namedExportsList.length) {%>{ <%=namedExportsList %> }<%} %> from <%=quoteSymbol %><%=path %><%=quoteSymbol %>;


### PR DESCRIPTION
Before:
```
import renderer from 'react-test-renderer';
import React from 'react';
import MyComponent from './MyComponent';

const renderTree = tree => renderer.create(tree);
describe('<MyComponent>', () => {
  it('should render component', () => {
    expect(renderTree(<MyComponent  
     />).toJSON()).toMatchSnapshot();
  });
  it('should render component with props', () => {
    expect(renderTree(<MyComponent  
    />).toJSON()).toMatchSnapshot();
  });
});
```

After:
```
import { render } from '@testing-library/react';
import React from 'react';
import MyComponent from './MyComponent';

describe('<MyComponent>', () => {
  it('should render component', () => {
    render(<MyComponent  
    />);
    expect(document.querySelector('body')).toMatchSnapshot();
  });
  it('should render component with props', () => {
    render(<MyComponent  
    />);
    expect(document.querySelector('body')).toMatchSnapshot();
  });
});
```